### PR TITLE
Add -git version of GLFW

### DIFF
--- a/libdecor.json
+++ b/libdecor.json
@@ -1,0 +1,22 @@
+{
+  "name": "libdecor",
+  "buildsystem": "meson",
+  "config-opts": [
+    "-Ddemo=false"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://gitlab.freedesktop.org/libdecor/libdecor.git",
+      "commit": "73260393a97291c887e1074ab7f318e031be0ac6"
+    },
+    {
+      "type": "patch",
+      "path": "patches/weird_libdecor.patch"
+    }
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig"
+  ]
+}

--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -33,6 +33,9 @@ modules:
   # Might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
   - shared-modules/libusb/libusb.json
 
+  # Needed for proper Wayland support
+  - libdecor.json
+
   - name: prismlauncher
     buildsystem: cmake-ninja
     builddir: true
@@ -64,6 +67,27 @@ modules:
       - mv /app/jre /app/jdk/8
     cleanup:
       - /jre
+
+  - name: glfw
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DBUILD_SHARED_LIBS:BOOL=ON
+      - -DGLFW_USE_WAYLAND=ON
+    sources:
+      - type: git
+        url: https://github.com/glfw/glfw.git
+        commit: 3fa2360720eeba1964df3c0ecf4b5df8648a8e52
+      - type: patch
+        path: patches/0003-Don-t-crash-on-calls-to-focus-or-icon.patch
+      - type: patch
+        path: patches/0005-Add-warning-about-being-an-unofficial-patch.patch
+      - type: patch
+        path: patches/0007-Platform-Prefer-Wayland-over-X11.patch
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
 
   - name: xrandr
     buildsystem: autotools

--- a/patches/0003-Don-t-crash-on-calls-to-focus-or-icon.patch
+++ b/patches/0003-Don-t-crash-on-calls-to-focus-or-icon.patch
@@ -1,0 +1,24 @@
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 52d3b9eb..4ac4eb5d 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2117,8 +2117,7 @@ void _glfwSetWindowTitleWayland(_GLFWwindow* window, const char* title)
+ void _glfwSetWindowIconWayland(_GLFWwindow* window,
+                                int count, const GLFWimage* images)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window icon");
++    fprintf(stderr, "!!! Ignoring Error: Wayland: The platform does not support setting the window icon\n");
+ }
+ 
+ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+@@ -2361,8 +2360,7 @@ void _glfwRequestWindowAttentionWayland(_GLFWwindow* window)
+ 
+ void _glfwFocusWindowWayland(_GLFWwindow* window)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the input focus");
++    fprintf(stderr, "!!! Ignoring Error: Wayland: The platform does not support setting the input focus\n");
+ }
+ 
+ void _glfwSetWindowMonitorWayland(_GLFWwindow* window,

--- a/patches/0005-Add-warning-about-being-an-unofficial-patch.patch
+++ b/patches/0005-Add-warning-about-being-an-unofficial-patch.patch
@@ -1,0 +1,17 @@
+diff --git a/src/init.c b/src/init.c
+index 06dbb3f2..a7c6da86 100644
+--- a/src/init.c
++++ b/src/init.c
+@@ -449,6 +449,12 @@ GLFWAPI int glfwInit(void)
+     _glfw.initialized = GLFW_TRUE;
+ 
+     glfwDefaultWindowHints();
++
++    fprintf(stderr, "!!! Patched GLFW from https://github.com/Admicos/minecraft-wayland\n"
++         "!!! If any issues with the window, or some issues with rendering, occur, "
++         "first try with the built-in GLFW, and if that solves the issue, report there first.\n"
++         "!!! Use outside Minecraft is untested, and things might break.\n");
++
+     return GLFW_TRUE;
+ }
+ 

--- a/patches/0007-Platform-Prefer-Wayland-over-X11.patch
+++ b/patches/0007-Platform-Prefer-Wayland-over-X11.patch
@@ -1,0 +1,20 @@
+diff --git a/src/platform.c b/src/platform.c
+index c5966ae7..3e7442f9 100644
+--- a/src/platform.c
++++ b/src/platform.c
+@@ -49,12 +49,12 @@ static const struct
+ #if defined(_GLFW_COCOA)
+     { GLFW_PLATFORM_COCOA, _glfwConnectCocoa },
+ #endif
+-#if defined(_GLFW_X11)
+-    { GLFW_PLATFORM_X11, _glfwConnectX11 },
+-#endif
+ #if defined(_GLFW_WAYLAND)
+     { GLFW_PLATFORM_WAYLAND, _glfwConnectWayland },
+ #endif
++#if defined(_GLFW_X11)
++    { GLFW_PLATFORM_X11, _glfwConnectX11 },
++#endif
+ };
+ 
+ GLFWbool _glfwSelectPlatform(int desiredID, _GLFWplatform* platform)

--- a/patches/weird_libdecor.patch
+++ b/patches/weird_libdecor.patch
@@ -1,0 +1,40 @@
+diff --git a/src/libdecor.c b/src/libdecor.c
+index a9c1106..1aa38b3 100644
+--- a/src/libdecor.c
++++ b/src/libdecor.c
+@@ -1391,22 +1391,32 @@ calculate_priority(const struct libdecor_plugin_description *plugin_description)
+ static bool
+ check_symbol_conflicts(const struct libdecor_plugin_description *plugin_description)
+ {
++	bool ret = true;
+ 	char * const *symbol;
++	void* main_prog = dlopen(NULL, RTLD_LAZY);
++	if (!main_prog) {
++		fprintf(stderr, "Plugin \"%s\" couldn't check conflicting symbols: \"%s\".\n",
++					plugin_description->description, dlerror());
++		return false;
++	}
++
+ 
+ 	symbol = plugin_description->conflicting_symbols;
+ 	while (*symbol) {
+ 		dlerror();
+-		dlsym (RTLD_DEFAULT, *symbol);
++		dlsym (main_prog, *symbol);
+ 		if (!dlerror()) {
+ 			fprintf(stderr, "Plugin \"%s\" uses conflicting symbol \"%s\".\n",
+ 					plugin_description->description, *symbol);
+-			return false;
++			ret = false;
++			break;
+ 		}
+ 
+ 		symbol++;
+ 	}
+ 
+-	return true;
++	dlclose(main_prog);
++	return ret;
+ }
+ 
+ static struct plugin_loader *


### PR DESCRIPTION
Tested and working with Minecraft 1.20.

Needs the `-Dorg.lwjgl.glfw.libname=/app/lib/libglfw.so` java argument to work, as the "use system installation of GLFW" option is broken on newer Minecraft versions.