### PR TITLE
Remove seemingly unnecessary, '--device=all' in favor of '--device=dri'

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -18,7 +18,7 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=wayland
-  - --device=all
+  - --device=dri
   - --share=network
   - --socket=pulseaudio
     # for Discord RPC mods


### PR DESCRIPTION
It seems a bit excessive to have full device access when only access to the GPU is needed. Don't know exactly if this breaks anything , but prismlauncher launches fine, plays fine, and behaves as before with these changes from what i've seen/played myself