### PR TITLE
Add glxinfo

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -26,9 +26,13 @@ finish-args:
     # Mod drag&drop
   - --filesystem=xdg-download:ro
 
+cleanup:
+  - /lib/libGLU*
+
 modules:
   # Might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
   - shared-modules/libusb/libusb.json
+
   - name: prismlauncher
     buildsystem: cmake-ninja
     builddir: true
@@ -100,6 +104,33 @@ modules:
       - /include
       - /lib/pkgconfig
       - /lib/libgamemodeauto.a
+
+  - name: glxinfo
+    buildsystem: meson
+    config-opts:
+      - --bindir=/app/mesa-demos
+      - -Degl=disabled
+      - -Dglut=disabled
+      - -Dosmesa=disabled
+      - -Dvulkan=disabled
+      - -Dwayland=disabled
+    post-install:
+      - mv -v /app/mesa-demos/glxinfo /app/bin
+    sources:
+      - type: archive
+        url: https://archive.mesa3d.org/demos/mesa-demos-9.0.0.tar.xz
+        sha256: 3046a3d26a7b051af7ebdd257a5f23bfeb160cad6ed952329cdff1e9f1ed496b
+        x-checker-data:
+          type: anitya
+          project-id: 16781
+          stable-only: true
+          url-template: https://archive.mesa3d.org/demos/mesa-demos-$version.tar.xz
+    cleanup:
+      - /include
+      - /mesa-demos
+      - /share
+    modules:
+      - shared-modules/glu/glu-9.json
 
   - name: enhance
     buildsystem: simple


### PR DESCRIPTION
Suppresses this message whenever you launch Minecraft:

```
sh: line 1: glxinfo: command not found
```

From what I can tell, Prism appears to only use `glxinfo` for hardware probing [in a single place](https://github.com/PrismLauncher/PrismLauncher/blob/7.1/launcher/minecraft/launch/PrintInstanceInfo.cpp#L137).

So, if you think this addition is not that important, feel free to disregard this pull request.

The `glxinfo` binary adds only ~300 KiB to the size of the app, so I thought: Why not? ¯\\\_(ツ)_/¯