### PR TITLE
Use runtime-provided gamescope rather than Steam

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -5,13 +5,6 @@ sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
-add-extensions:
-  com.valvesoftware.Steam.Utility.gamescope:
-    version: stable
-    add-ld-path: lib
-    no-autodownload: true
-    autodelete: false
-    directory: utils/gamescope
 
 command: prismlauncher
 finish-args:
@@ -159,7 +152,6 @@ modules:
   - name: enhance
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/utils/gamescope
       - install -Dm755 prime-run /app/bin/prime-run
       - mv /app/bin/prismlauncher /app/bin/prismrun
       - install -Dm755 prismlauncher /app/bin/prismlauncher

--- a/prismlauncher
+++ b/prismlauncher
@@ -5,7 +5,7 @@ for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/discord-ipc-"$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/discord-ipc-"$i";
 done
 
-export PATH="${PATH}${PATH:+:}/app/utils/gamescope/bin:/usr/lib/extensions/vulkan/MangoHud/bin"
+export PATH="${PATH}${PATH:+:}/usr/lib/extensions/vulkan/gamescope/bin:/usr/lib/extensions/vulkan/MangoHud/bin"
 export VK_LAYER_PATH="/usr/lib/extensions/vulkan/share/vulkan/implicit_layer.d/"
 
 exec /app/bin/prismrun "$@"


### PR DESCRIPTION
Depends on https://github.com/flathub/flathub/pull/4329 
Closes https://github.com/flathub/org.prismlauncher.PrismLauncher/issues/11 
Required after https://github.com/flathub/com.valvesoftware.Steam.Utility.gamescope/pull/150