### PR TITLE
Expose the transparent hugepages (THP) configuration so the `-XX:+UseTransparentHugePages` java setting works

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -21,6 +21,12 @@ finish-args:
   - --filesystem=xdg-download:ro
     # FTBApp import
   - --filesystem=~/.ftba:ro
+    # Userspace visibility for manual hugepages configuration
+    # Required for -XX:+UseLargePages
+  - --filesystem=/sys/kernel/mm/hugepages:ro
+    # Userspace visibility for transparent hugepages configuration
+    # Required for -XX:+UseTransparentHugePages
+  - --filesystem=/sys/kernel/mm/transparent_hugepage:ro
 
 cleanup:
   - /lib/libGLU*


### PR DESCRIPTION
Closes #61

Java is able to make use of hugepages to greatly reduce pagetable lookups by allowing the process to map larger chunks of RAM at a time. This is [known to boost Minecraft performance on both the server and client](https://github.com/brucethemoose/Minecraft-Performance-Flags-Benchmarks?tab=readme-ov-file#large-pages). The Linux kernel in particular offers [transparent hugepages](https://www.kernel.org/doc/html/next/admin-guide/mm/transhuge.html), which allows userspace processes to specify whether they prefer hugepages, without needing root access. In order for Java to detect this, it needs to see the kernel-side switches in `/sys/kernel/mm/transparent_hugepage/`.

Because the Flatpak sandboxing restricts access to some parts of `/sys/`, enabling THP in Minecraft results in this error:

```
[0.016s][warning][pagesize] UseTransparentHugePages disabled, transparent huge pages are not supported by the operating system.
```

Thankfully, Java is designed to fallback to non-THP, so adding the flag doesn't cause the user's instances to crash, but it silently disables an option that otherwise could work. The `/sys/` files in question are accessed in [`jdk21u/src/hotspot/os/linux/hugepages.cpp`](https://github.com/openjdk/jdk21u/blob/master/src/hotspot/os/linux/hugepages.cpp#L185-L217).

These can be exposed as read-only in the Flatpak, to enable the JVM to properly go into THP mode. We can also expose the manually configured hugepages, for whoever is still using this. On a typical system, the contents of the files exposed might be:

```
/sys/kernel/mm/hugepages/hugepages-2048kB/nr_overcommit_hugepages
0

/sys/kernel/mm/transparent_hugepage/hugepages-128kB/enabled
always inherit madvise [never]

/sys/kernel/mm/hugepages/hugepages-2048kB/surplus_hugepages
0

/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
0

/sys/kernel/mm/transparent_hugepage/hpage_pmd_size
2097152

/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages_mempolicy
0

/sys/kernel/mm/hugepages/hugepages-2048kB/resv_hugepages
0

/sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages
0

/sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise [madvise] never

/sys/kernel/mm/transparent_hugepage/hugepages-2048kB/enabled
always [inherit] madvise never

/sys/kernel/mm/transparent_hugepage/hugepages-256kB/enabled
always inherit madvise [never]

/sys/kernel/mm/transparent_hugepage/enabled
always [madvise] never

/sys/kernel/mm/transparent_hugepage/shmem_enabled
always within_size advise [never] deny force

/sys/kernel/mm/transparent_hugepage/hugepages-32kB/enabled
always inherit madvise [never]

/sys/kernel/mm/transparent_hugepage/use_zero_page
1

/sys/kernel/mm/transparent_hugepage/hugepages-512kB/enabled
always inherit madvise [never]

/sys/kernel/mm/transparent_hugepage/khugepaged/defrag
1

/sys/kernel/mm/transparent_hugepage/khugepaged/full_scans
45

/sys/kernel/mm/transparent_hugepage/khugepaged/pages_to_scan
4096

/sys/kernel/mm/transparent_hugepage/khugepaged/scan_sleep_millisecs
10000

/sys/kernel/mm/transparent_hugepage/khugepaged/pages_collapsed
851

/sys/kernel/mm/transparent_hugepage/hugepages-16kB/enabled
always inherit madvise [never]

/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_shared
256

/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none
511

/sys/kernel/mm/transparent_hugepage/khugepaged/alloc_sleep_millisecs
60000

/sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_swap
64

/sys/kernel/mm/transparent_hugepage/hugepages-64kB/enabled
always inherit madvise [never]

/sys/kernel/mm/transparent_hugepage/hugepages-1024kB/enabled
always inherit madvise [never]
```

Doing this allows the usage of `-XX:+UseTransparentHugePages` in Minecraft and makes the warning go away. I have verified that this makes the Java process show `AnonHugePages` in `/proc/$pid/smaps`, indicating that THP is now working properly through the sandboxing.