### PR TITLE
Revert "Remove Java 17"

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -2,6 +2,8 @@ id: org.prismlauncher.PrismLauncher
 runtime: org.kde.Platform
 runtime-version: '6.7'
 sdk: org.kde.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
 
 command: prismlauncher
 finish-args:


### PR DESCRIPTION
Reverts flathub/org.prismlauncher.PrismLauncher#78

I should learn how flatpak works 😆
This isn't a dependency for runtime but instead of building, apparently