### PR TITLE
Add ffmpeg for replay mod

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -1,11 +1,20 @@
 id: org.prismlauncher.PrismLauncher
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
-
 command: prismlauncher
+
+add-extensions:
+  # Replay mod require ffmpeg to export video
+  org.freedesktop.Platform.ffmpeg-full:
+    version: '24.08'
+    directory: lib/ffmpeg
+    add-ld-path: .
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+
 finish-args:
   - --share=ipc
   - --socket=x11
@@ -25,7 +34,6 @@ finish-args:
     # Userspace visibility for transparent hugepages configuration
     # Required for -XX:+UseTransparentHugePages
   - --filesystem=/sys/kernel/mm/transparent_hugepage:ro
-
 modules:
   # Might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
   - shared-modules/libusb/libusb.json


### PR DESCRIPTION
Without the extension, replay mod crash when you try to export a video as mp4
```
Description: Exporting video
com.replaymod.render.FFmpegWriter$FFmpegStartupException: null
	at com.replaymod.render.FFmpegWriter.getVideoFile(FFmpegWriter.java:163) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
	at com.replaymod.render.FFmpegWriter.consume(FFmpegWriter.java:121) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
	at com.replaymod.render.rendering.VideoRenderer$1.consume(VideoRenderer.java:161) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
	at com.replaymod.render.rendering.Pipeline$ParallelSafeConsumer.consume(Pipeline.java:150) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
	at com.replaymod.render.rendering.Pipeline$ProcessTask.run(Pipeline.java:118) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?] {}
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?] {}
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?] {}
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?] {}
	at java.lang.Thread.run(Thread.java:833) ~[?:?] {re:mixin}
...
[vost#0:0 @ 0x55ff0872e480] Unknown encoder 'libx264'
[vost#0:0 @ 0x55ff0872e480] Error selecting an encoder
Error opening output file 2025_09_02_20_37_45.mp4.
Error opening output files: Encoder not found
```
(thanks @renner0e for the help)

p.s. my apologies for the messy git
