### PR TITLE
Add ffmpeg-full for replay mod

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -6,6 +6,16 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
 
 command: prismlauncher
+
+add-extensions:
+  # Replay mod require ffmpeg to export video
+  org.freedesktop.Platform.ffmpeg-full:
+    version: '24.08'
+    directory: lib/ffmpeg
+    add-ld-path: .
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+
 finish-args:
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
Identical to #95, but with a neater tree (my apologies for the messy git)

It seems like the FFmpeg shipped with the runtime is missing libx264, causing replay mod to crash. On the other hand, ffmpeg-full does ship libx264, replay mod is able to export video properly.

Original description:
> Without the extension, replay mod crash when you try to export a video as mp4
> ```
> Description: Exporting video
> com.replaymod.render.FFmpegWriter$FFmpegStartupException: null
> 	at com.replaymod.render.FFmpegWriter.getVideoFile(FFmpegWriter.java:163) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
> 	at com.replaymod.render.FFmpegWriter.consume(FFmpegWriter.java:121) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
> 	at com.replaymod.render.rendering.VideoRenderer$1.consume(VideoRenderer.java:161) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
> 	at com.replaymod.render.rendering.Pipeline$ParallelSafeConsumer.consume(Pipeline.java:150) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
> 	at com.replaymod.render.rendering.Pipeline$ProcessTask.run(Pipeline.java:118) ~[reforgedplaymod-1.20.1-0.3.1.jar%23219!/:?] {re:classloading}
> 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?] {}
> 	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?] {}
> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?] {}
> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?] {}
> 	at java.lang.Thread.run(Thread.java:833) ~[?:?] {re:mixin}
> ...
> [vost#0:0 @ 0x55ff0872e480] Unknown encoder 'libx264'
> [vost#0:0 @ 0x55ff0872e480] Error selecting an encoder
> Error opening output file 2025_09_02_20_37_45.mp4.
> Error opening output files: Encoder not found
> ```
> (thanks @renner0e for the help)
> 
> p.s. my apologies for the messy git
