### PR TITLE
Wrapper extension point

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -27,14 +27,14 @@ finish-args:
   - --filesystem=/sys/kernel/mm/transparent_hugepage:ro
 
 add-extensions:
-  org.prismlauncher.PrismLauncher.Wrapper:
-    directory: wrappers
+  org.prismlauncher.PrismLauncher.Extension:
+    directory: extension
     subdirectories: true
     no-autodownload: true
     autodelete: true
 
 cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/wrappers
+  - mkdir -p ${FLATPAK_DEST}/extension
 
 modules:
   - cmark.yml

--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -28,13 +28,13 @@ finish-args:
 
 add-extensions:
   org.prismlauncher.PrismLauncher.Extension:
-    directory: extension
+    directory: extensions
     subdirectories: true
     no-autodownload: true
     autodelete: true
 
 cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/extension
+  - mkdir -p ${FLATPAK_DEST}/extensions
 
 modules:
   - cmark.yml

--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -26,6 +26,16 @@ finish-args:
     # Required for -XX:+UseTransparentHugePages
   - --filesystem=/sys/kernel/mm/transparent_hugepage:ro
 
+add-extensions:
+  org.prismlauncher.PrismLauncher.Wrapper:
+    directory: wrappers
+    subdirectories: true
+    no-autodownload: true
+    autodelete: true
+
+cleanup-commands:
+  - mkdir -p ${FLATPAK_DEST}/wrappers
+
 modules:
   - cmark.yml
   - tomlplusplus.yml

--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -29,6 +29,7 @@ finish-args:
 add-extensions:
   org.prismlauncher.PrismLauncher.Extension:
     directory: extensions
+    add-ld-path: lib
     subdirectories: true
     no-autodownload: true
     autodelete: true


### PR DESCRIPTION
Recently, in the minecraft speedrunning scene, there has been new tools such as [Waywall](https://tesselslate.github.io/waywall/index.html) which act as a wrapper around the minecraft instance to provide functionality for speedrunning.

Currently we tell new users of waywall to uninstall the flatpak of prismlauncher...

This PR would make it possible to package Waywall and other similar tools for flatpak as an extension, which would provide significant UX improvement

I have already created a proof of concept here https://github.com/mrshmllow/org.prismlauncher.PrismLauncher.Wrapper.waywall