### PR TITLE
Add a note regarding device=all

### DIFF
--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -10,8 +10,10 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=wayland
-  - --device=dri
-  - --device=input
+  - --device=all
+  #- --device=dri
+  #- --device=input
+  # Can't use these yet without an exception from the flathub team, wait for support https://github.com/flathub/org.prismlauncher.PrismLauncher/issues/48
   - --share=network
   - --socket=pulseaudio
     # for Discord RPC mods

--- a/org.prismlauncher.PrismLauncher.yml
+++ b/org.prismlauncher.PrismLauncher.yml
@@ -10,7 +10,8 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=wayland
-  - --device=all
+  - --device=dri
+  - --device=input
   - --share=network
   - --socket=pulseaudio
     # for Discord RPC mods


### PR DESCRIPTION
Seeing as it's been 2 years since this issue: https://github.com/flathub/org.prismlauncher.PrismLauncher/issues/48
I think it's about time the device=all permission gets replaced with device=input

Tested this with a controller and it seems to work just fine.

device=dri is needed for dgpu.